### PR TITLE
Align model with enu coordinates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 path?=${CURDIR}/dataset
 
 clean:
-	rm -rf dataset/*
-	
+	rm -rf dataset/dense/*
+	rm -rf dataset/sparse/*
+	rm -rf dataset/database.db
 
 increment:
 	./scripts/incremental_reconstruction.sh ${path} .

--- a/README.md
+++ b/README.md
@@ -4,10 +4,16 @@ This repository contains tools for evaluating photogrammetry results using [COLM
 
 ![image](https://user-images.githubusercontent.com/5248102/147664343-2aa926fe-9c35-4b02-8dd8-621602c7ea99.png)
 
+## Photogrammetry Reconstructions
+Photogrammetric reconstruction for a dataset can be run with the following command
+```
+make run [path=<path to dataset>]
+```
+
 ## Incremental Photogrammetry Reconstructions
 Photogrammetric reconstruction with incrementally increasing the number of images can be run with the following command
 ```
-make run [path=<path to dataset>]
+make run-subset [path=<path to dataset>]
 ```
 The reconstruction results can be found in the `./output` directory at the root of the repository.
 

--- a/scripts/reconstruction.sh
+++ b/scripts/reconstruction.sh
@@ -27,6 +27,7 @@ colmap model_aligner \
     --ref_images_path $DATASET_PATH/camera.txt \
     --alignment_type enu \
     --robust_alignment 1 \
+    --ref_is_gps 0 \
     --robust_alignment_max_error 3 \
     --transform_path $DATASET_PATH/transform.txt
 

--- a/scripts/register.sh
+++ b/scripts/register.sh
@@ -13,5 +13,6 @@ colmap model_aligner \
     --ref_images_path $DATASET_PATH/camera.txt \
     --alignment_type enu \
     --robust_alignment 1 \
+    --ref_is_gps 0 \
     --robust_alignment_max_error 3 \
     --transform_path $DATASET_PATH/transform.txt


### PR DESCRIPTION
**Problem Description**
The model aligner didn't seem to work with the enu camera coordinates provided.

This seems to be caused by a bug in previous colmap version. Updating this to colmap `3.7` fixed the problem

**Proposed Solution**
This script updates the config to not use gps coordinates with `ref_is_gps` flag.

The PR that fixed the problem is: https://github.com/colmap/colmap/pull/1371

**Testing**
Cloudcompare alignment seems to have a good orientation alignment coming from the model aligner:

![image](https://user-images.githubusercontent.com/5248102/188431340-2a4401ae-6852-4685-ae25-478065ac1e90.png)

Where the transform is as the following: 
```
1.000000 -0.000886 0.000867 374.811401
0.000887 0.999999 -0.000799 -723.035217
-0.000866 0.000800 0.999999 -287.127594
0.000000 0.000000 0.000000 1.000000
```

This closely matches the player start location of the unreal engine:     
```
auto player_start = Eigen::Vector3d(374.47859375, -723.12984375, -286.77371094);
```
