### PR TITLE
Fix vertical datum for gps altitude

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,12 @@ cmake_minimum_required(VERSION 2.8.12)
 project(photogrammetry_evaluations)
 
 add_definitions(-std=c++17)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 find_package(GDAL)
 find_package(OpenCV REQUIRED)
+find_package(GeographicLib REQUIRED)
+include(CheckGeographicLibDatasets)
 
 find_package(catkin REQUIRED COMPONENTS
   roscpp
@@ -35,6 +38,7 @@ include_directories(
   ${catkin_INCLUDE_DIRS}
   ${Eigen_INCLUDE_DIRS}
   ${GDAL_INCLUDE_DIRS}
+  ${GeographicLib_INCLUDE_DIRS}
 )
 
 add_library(${PROJECT_NAME}
@@ -56,7 +60,7 @@ add_executable(replay_node
   src/replay_node.cpp
 )
 add_dependencies(replay_node ${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS} ${GDAL_LIBRARY})
-target_link_libraries(replay_node ${PROJECT_NAME} ${catkin_LIBRARIES} ${GDAL_LIBRARY} ${OpenCV_LIBRARIES} pthread)
+target_link_libraries(replay_node ${PROJECT_NAME} ${catkin_LIBRARIES} ${GDAL_LIBRARY} ${OpenCV_LIBRARIES} pthread ${GeographicLib_LIBRARIES})
 
 #############
 ## Testing ##

--- a/cmake/CheckGeographicLibDatasets.cmake
+++ b/cmake/CheckGeographicLibDatasets.cmake
@@ -1,0 +1,27 @@
+##
+# This module verifies the installation of the GeographicLib datasets and warns
+# if it doesn't detect them.
+##
+
+find_path(GEOGRAPHICLIB_GEOID_PATH NAMES geoids PATH_SUFFIXES share/GeographicLib share/geographiclib)
+find_path(GEOGRAPHICLIB_GRAVITY_PATH_ NAMES gravity PATH_SUFFIXES share/GeographicLib)
+find_path(GEOGRAPHICLIB_MAGNETIC_PATH_ NAMES magnetic PATH_SUFFIXES share/GeographicLib)
+
+if(NOT GEOGRAPHICLIB_GEOID_PATH)
+  message(STATUS "No geoid model datasets found. This will result on a SIGINT! Please execute the script install_geographiclib_dataset.sh in /mavros/scripts")
+else()
+  message(STATUS "Geoid model datasets found in: " ${GEOGRAPHICLIB_GEOID_PATH}/geoid)
+  set(GEOGRAPHICLIB_GEOID_PATH ${GEOGRAPHICLIB_GEOID_PATH}/geoid)
+endif()
+if(NOT GEOGRAPHICLIB_GRAVITY_PATH_)
+  message(STATUS "No gravity field model datasets found. Please execute the script install_geographiclib_dataset.sh in /mavros/scripts")
+else()
+  message(STATUS "Gravity Field model datasets found in: " ${GEOGRAPHICLIB_GRAVITY_PATH_}/gravity)
+  set(GEOGRAPHICLIB_GRAVITY_PATH ${GEOGRAPHICLIB_GRAVITY_PATH_}/gravity)
+endif()
+if(NOT GEOGRAPHICLIB_MAGNETIC_PATH_)
+  message(STATUS "No magnetic field model datasets found. Please execute the script install_geographiclib_dataset.sh in /mavros/scripts")
+else()
+  message(STATUS "Magnetic Field model datasets found in: " ${GEOGRAPHICLIB_MAGNETIC_PATH_}/magnetic)
+  set(GEOGRAPHICLIB_MAGNETIC_PATH ${GEOGRAPHICLIB_MAGNETIC_PATH_}/magnetic)
+endif()

--- a/cmake/FindGeographicLib.cmake
+++ b/cmake/FindGeographicLib.cmake
@@ -1,0 +1,18 @@
+# Look for GeographicLib
+#
+# Set
+#  GEOGRAPHICLIB_FOUND = TRUE
+#  GeographicLib_INCLUDE_DIRS = /usr/local/include
+#  GeographicLib_LIBRARIES = /usr/local/lib/libGeographic.so
+#  GeographicLib_LIBRARY_DIRS = /usr/local/lib
+
+find_path (GeographicLib_INCLUDE_DIRS NAMES GeographicLib/Config.h)
+
+find_library (GeographicLib_LIBRARIES NAMES Geographic)
+
+include (FindPackageHandleStandardArgs)
+find_package_handle_standard_args (GeographicLib DEFAULT_MSG
+  GeographicLib_LIBRARIES GeographicLib_INCLUDE_DIRS)
+mark_as_advanced (GeographicLib_LIBRARIES GeographicLib_INCLUDE_DIRS)
+
+#message(WARNING "GL: F:${GeographicLib_FOUND} L:${GeographicLib_LIBRARIES} I:${GeographicLib_INCLUDE_DIRS}")

--- a/launch/config_replay.rviz
+++ b/launch/config_replay.rviz
@@ -12,7 +12,6 @@ Panels:
         - /Path1
         - /MarkerArray2
         - /GridMap2
-        - /GridMap2/Status1
       Splitter Ratio: 0.5
     Tree Height: 845
   - Class: rviz/Selection
@@ -58,12 +57,12 @@ Visualization Manager:
       Plane Cell Count: 10
       Reference Frame: <Fixed Frame>
       Value: true
-    - Alpha: 1
+    - Alpha: 0.5
       Autocompute Intensity Bounds: true
       Class: grid_map_rviz_plugin/GridMap
       Color: 0; 0; 255
-      Color Layer: color
-      Color Transformer: ColorLayer
+      Color Layer: geometric_prior
+      Color Transformer: IntensityLayer
       Enabled: true
       Height Layer: elevation
       Height Transformer: GridMapLayer
@@ -126,7 +125,7 @@ Visualization Manager:
       Color Layer: elevation
       Color Transformer: GridMapLayer
       Enabled: true
-      Height Layer: elevation
+      Height Layer: reconstruction
       Height Transformer: GridMapLayer
       History Length: 1
       Invert Rainbow: false
@@ -168,7 +167,7 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz/Orbit
-      Distance: 2093.55322265625
+      Distance: 1886.306640625
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
@@ -176,17 +175,17 @@ Visualization Manager:
         Value: false
       Field of View: 0.7853981852531433
       Focal Point:
-        X: 330.3721618652344
-        Y: 547.2584228515625
-        Z: 377.08349609375
+        X: 263.2138671875
+        Y: 595.13720703125
+        Z: 414.2058410644531
       Focal Shape Fixed Size: true
       Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.5547971129417419
+      Pitch: 0.5097969770431519
       Target Frame: <Fixed Frame>
-      Yaw: 4.514819622039795
+      Yaw: 4.209819793701172
     Saved: ~
 Window Geometry:
   Displays:


### PR DESCRIPTION
**Problem Description**
This PR fixes the geotag datum wrongly being used as wgs84. 

The GPS altitude is based on AMSL, therefore the offset from the geoid to ellipsoid needs to be applied.

Fixes https://github.com/Jaeyoung-Lim/photogrammetry-evaluations/pull/24

**Before PR**
![rviz_screenshot_2023_11_21-09_38_01](https://github.com/Jaeyoung-Lim/photogrammetry-evaluations/assets/5248102/3abcb90e-79a2-4627-8c79-fa8e95f8a9e7)

**After PR**
![rviz_screenshot_2023_11_21-10_31_22](https://github.com/Jaeyoung-Lim/photogrammetry-evaluations/assets/5248102/683f2c95-8e5a-49f7-a68d-4d195bef56e8)
